### PR TITLE
Add removeConsonant tests

### DIFF
--- a/src/js/tests/articulation.test.ts
+++ b/src/js/tests/articulation.test.ts
@@ -26,7 +26,8 @@ test('strokeNickname defaults to da for d stroke', () => {
   expect(a.hindi).toBeUndefined();
   expect(a.ipa).toBeUndefined();
   expect(a.engTrans).toBeUndefined();
-  
+});
+
 test('stroke r sets strokeNickname', () => {
   const a = new Articulation({ stroke: 'r' });
   expect(a.strokeNickname).toBe('ra');

--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -170,6 +170,40 @@ test('Trajectory consonant and vowel helpers', () => {
   const copy = Trajectory.fromJSON(json);
   expect(copy.startConsonant).toBe('kha');
 });
+
+test('removeConsonant(true) clears start consonant data', () => {
+  const t = new Trajectory({ pitches: [new Pitch()], durTot: 1 });
+  t.addConsonant('ka');
+  t.addConsonant('ga', false);
+
+  t.removeConsonant(true);
+
+  expect(t.startConsonant).toBeUndefined();
+  expect(t.startConsonantHindi).toBeUndefined();
+  expect(t.startConsonantIpa).toBeUndefined();
+  expect(t.startConsonantEngTrans).toBeUndefined();
+  expect(t.articulations['0.00']).toBeUndefined();
+
+  expect(t.endConsonant).toBe('ga');
+  expect(t.articulations['1.00']).toBeDefined();
+});
+
+test('removeConsonant(false) clears end consonant data', () => {
+  const t = new Trajectory({ pitches: [new Pitch()], durTot: 1 });
+  t.addConsonant('ka');
+  t.addConsonant('ga', false);
+
+  t.removeConsonant(false);
+
+  expect(t.endConsonant).toBeUndefined();
+  expect(t.endConsonantHindi).toBeUndefined();
+  expect(t.endConsonantIpa).toBeUndefined();
+  expect(t.endConsonantEngTrans).toBeUndefined();
+  expect(t.articulations['1.00']).toBeUndefined();
+
+  expect(t.startConsonant).toBe('ka');
+  expect(t.articulations['0.00']).toBeDefined();
+});
 describe('compute delegation for all ids', () => {
   const xs = linSpace(0, 1, 5);
   const cases = [


### PR DESCRIPTION
## Summary
- fix missing closure in articulation tests
- test that `removeConsonant(true)` clears the start consonant and articulation
- test that `removeConsonant(false)` clears the end consonant and articulation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9ce91f34832e9459a50bfb422480