### PR TITLE
Add vocal instrumentation default articulations test

### DIFF
--- a/src/js/tests/trajectory.test.ts
+++ b/src/js/tests/trajectory.test.ts
@@ -66,6 +66,11 @@ test.each([Instrument.Vocal_M, Instrument.Vocal_F])('vocal instrumentation remov
   expect(t.articulations).toEqual({});
 });
 
+test('vocal instrumentation default articulations are empty', () => {
+  const traj = new Trajectory({ instrumentation: Instrument.Vocal_M });
+  expect(traj.articulations).toEqual({});
+});
+
 /* ───────────────────────── JSON round-trip ───────────────────────── */
 
 test('trajectory JSON round trip', () => {


### PR DESCRIPTION
## Summary
- add a test verifying no articulations for Vocal_M instrumentation when none are specified

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebc15dc24832e9844c79a26304edf