### PR TITLE
Add >50 cent pitch deviation tests

### DIFF
--- a/src/js/tests/pitch.test.ts
+++ b/src/js/tests/pitch.test.ts
@@ -507,6 +507,14 @@ test('westernPitch note name', () => {
   expect(p.westernPitch).toBe('D');
 });
 
+test('a440CentsDeviation > 50 cents handling', () => {
+  const re = new Pitch({ swara: 're', raised: true, logOffset: 0.05 });
+  expect(re.a440CentsDeviation).toBe('E4 (-40\u00A2)');
+
+  const ni = new Pitch({ swara: 'ni', raised: true, logOffset: 0.05 });
+  expect(ni.a440CentsDeviation).toBe('C#4 (-40\u00A2)');
+});
+
 test('constructor rejects undefined ratios', () => {
   const baseRatios = [
     1,


### PR DESCRIPTION
## Summary
- cover `a440CentsDeviation` branch for offsets over 50 cents

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ebcc6560c832ea8b770aa657c5416