### PR TITLE
Add missing grid padding test

### DIFF
--- a/src/js/tests/phrase.test.ts
+++ b/src/js/tests/phrase.test.ts
@@ -328,3 +328,19 @@ test('constructor pads grids to instrumentation length', () => {
   expect(phrase.trajectoryGrid[1]).toEqual([]);
   expect(phrase.chikariGrid[1]).toEqual({});
 });
+
+test('constructor fills missing trajectory/chikari grids when undefined', () => {
+  const traj = new Trajectory();
+  const instrumentation = ['Sitar', 'Violin', 'Sarod'];
+  const phrase = new Phrase({ trajectories: [traj], instrumentation });
+
+  expect(phrase.trajectoryGrid.length).toBe(instrumentation.length);
+  expect(phrase.chikariGrid.length).toBe(instrumentation.length);
+
+  expect(phrase.trajectoryGrid[0]).toEqual([traj]);
+  expect(phrase.chikariGrid[0]).toEqual({});
+  expect(phrase.trajectoryGrid[1]).toEqual([]);
+  expect(phrase.trajectoryGrid[2]).toEqual([]);
+  expect(phrase.chikariGrid[1]).toEqual({});
+  expect(phrase.chikariGrid[2]).toEqual({});
+});


### PR DESCRIPTION
## Summary
- cover constructor behavior when trajectoryGrid and chikariGrid are undefined

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ebe8797b4832ea5c5fcbfec9e2fa6