### PR TITLE
Add trajectory zero-duration test for Python port

### DIFF
--- a/python/api/classes/__init__.py
+++ b/python/api/classes/__init__.py
@@ -1,0 +1,5 @@
+from .pitch import Pitch
+from .raga import Raga
+from .trajectory import Trajectory
+
+__all__ = ["Pitch", "Raga", "Trajectory"]

--- a/python/api/classes/trajectory.py
+++ b/python/api/classes/trajectory.py
@@ -1,0 +1,36 @@
+from typing import Optional, TypedDict, List
+import humps
+import math
+from .pitch import Pitch
+
+class TrajectoryOptionsType(TypedDict, total=False):
+    id: int
+    pitches: List[Pitch]
+    dur_tot: float
+    dur_array: List[float]
+
+class Trajectory:
+    def __init__(self, options: Optional[TrajectoryOptionsType] = None):
+        if options is None:
+            options = {}
+        else:
+            options = humps.decamelize(options)
+
+        self.id = options.get('id', 0)
+        self.pitches: List[Pitch] = options.get('pitches', [Pitch()])
+        self.dur_tot = options.get('dur_tot', 1.0)
+        self.dur_array = options.get('dur_array')
+        if self.dur_array is None:
+            self.dur_array = [1 / len(self.pitches)] * len(self.pitches)
+
+        idx = 0
+        while idx < len(self.dur_array):
+            if self.dur_array[idx] == 0:
+                self.dur_array.pop(idx)
+                if idx + 1 < len(self.pitches):
+                    self.pitches.pop(idx + 1)
+            else:
+                idx += 1
+
+        self.freqs = [p.frequency for p in self.pitches]
+        self.log_freqs = [math.log2(p.frequency) for p in self.pitches]

--- a/python/api/tests/trajectory_zero_test.py
+++ b/python/api/tests/trajectory_zero_test.py
@@ -1,0 +1,22 @@
+from python.api.classes.pitch import Pitch
+from python.api.classes.trajectory import Trajectory
+
+
+def test_constructor_removes_zero_duration_segments():
+    p0 = Pitch()
+    p1 = Pitch({"swara": 1})
+    p2 = Pitch({"swara": 2})
+
+    traj = Trajectory({
+        "id": 7,
+        "pitches": [p0, p1, p2],
+        "dur_array": [0.3, 0, 0.7],
+    })
+
+    assert traj.dur_array == [0.3, 0.7]
+    assert len(traj.pitches) == 2
+    assert traj.pitches[0] == p0
+    # pitch following the zero-duration segment should be removed
+    assert traj.pitches[1] == p1
+    assert len(traj.freqs) == 2
+    assert len(traj.log_freqs) == 2


### PR DESCRIPTION
## Summary
- create a minimal `Trajectory` class in the Python API
- expose `Trajectory` in the API package
- add a test verifying zero-duration segments are removed on construction

## Testing
- `python -m pytest python/api/tests -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ed01d071c832eb68952b607bc8f97