### PR TITLE
Add trajectory names class and test

### DIFF
--- a/python/api/classes/trajectory.py
+++ b/python/api/classes/trajectory.py
@@ -1,0 +1,22 @@
+class Trajectory:
+    def __init__(self):
+        self.names = [
+            'Fixed',
+            'Bend: Simple',
+            'Bend: Sloped Start',
+            'Bend: Sloped End',
+            'Bend: Ladle',
+            'Bend: Reverse Ladle',
+            'Bend: Simple Multiple',
+            'Krintin',
+            'Krintin Slide',
+            'Krintin Slide Hammer',
+            'Dense Krintin Slide Hammer',
+            'Slide',
+            'Silent',
+            'Vibrato'
+        ]
+
+    @classmethod
+    def names(cls):
+        return cls().names

--- a/python/api/tests/trajectory_test.py
+++ b/python/api/tests/trajectory_test.py
@@ -1,0 +1,7 @@
+from python.api.classes.trajectory import Trajectory
+
+
+def test_trajectory_names_matches_instance():
+    static_names = Trajectory.names()
+    instance = Trajectory()
+    assert static_names == instance.names


### PR DESCRIPTION
## Summary
- implement a minimal Python `Trajectory` class with default `names`
- add a test ensuring `Trajectory.names()` matches instance names

## Testing
- `python -m pytest python/api/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed01c527c832e8f75e85e413e2366