### PR TITLE
Add Python serialization test

### DIFF
--- a/python/api/tests/pitch_test.py
+++ b/python/api/tests/pitch_test.py
@@ -257,3 +257,9 @@ def test_numbered_pitch():
     p = Pitch({ 'swara': 3, 'raised': False, 'oct': 1 })
     assert p.numbered_pitch == 17
 
+
+def test_serialization_round_trip():
+    p = Pitch({'swara': 'ga', 'raised': False, 'oct': 1, 'logOffset': 0.2})
+    json_obj = p.to_JSON()
+    copy = Pitch(json_obj)
+    assert copy.to_JSON() == json_obj


### PR DESCRIPTION
## Summary
- test Pitch serialization round-trip in Python

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed014e1bc832e892c936f24cb1c0f