### PR TITLE
Add Articulation class and tests

### DIFF
--- a/humps.py
+++ b/humps.py
@@ -1,0 +1,15 @@
+import re
+from typing import Any
+
+def _decamelize_key(name: str) -> str:
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1)
+    return s2.lower()
+
+def decamelize(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return { _decamelize_key(k): decamelize(v) for k, v in obj.items() }
+    elif isinstance(obj, list):
+        return [decamelize(v) for v in obj]
+    else:
+        return obj

--- a/python/api/classes/articulation.py
+++ b/python/api/classes/articulation.py
@@ -1,0 +1,42 @@
+from typing import Optional, TypedDict
+import humps
+
+class ArticulationOptionsType(TypedDict, total=False):
+    name: str
+    stroke: str
+    hindi: str
+    ipa: str
+    eng_trans: str
+    stroke_nickname: str
+
+class Articulation:
+    def __init__(self, options: Optional[ArticulationOptionsType] = None):
+        if options is None:
+            options = {}
+        else:
+            options = humps.decamelize(options)
+        self.name = options.get('name', 'pluck')
+        self.stroke: Optional[str] = options.get('stroke')
+        self.hindi: Optional[str] = options.get('hindi')
+        self.ipa: Optional[str] = options.get('ipa')
+        self.eng_trans: Optional[str] = options.get('eng_trans')
+        self.stroke_nickname: Optional[str] = options.get('stroke_nickname')
+
+        if self.stroke == 'd' and self.stroke_nickname is None:
+            self.stroke_nickname = 'da'
+        elif self.stroke == 'r' and self.stroke_nickname is None:
+            self.stroke_nickname = 'ra'
+
+    @classmethod
+    def from_json(cls, obj: dict):
+        return cls(obj)
+
+    def to_json(self):
+        return {
+            'name': self.name,
+            'stroke': self.stroke,
+            'hindi': self.hindi,
+            'ipa': self.ipa,
+            'engTrans': self.eng_trans,
+            'strokeNickname': self.stroke_nickname,
+        }

--- a/python/api/tests/articulation_test.py
+++ b/python/api/tests/articulation_test.py
@@ -1,0 +1,55 @@
+from python.api.classes.articulation import Articulation
+
+def test_default_articulation():
+    a = Articulation()
+    assert isinstance(a, Articulation)
+    assert a.name == 'pluck'
+    assert a.stroke is None
+    assert a.hindi is None
+    assert a.ipa is None
+    assert a.eng_trans is None
+
+
+def test_articulation_from_json():
+    obj = {
+        'name': 'pluck',
+        'stroke': 'd',
+        'hindi': '\u0926',
+        'ipa': 'd̪',
+        'engTrans': 'da',
+        'strokeNickname': 'da'
+    }
+    a = Articulation.from_json(obj)
+    assert a.stroke == 'd'
+    assert a.stroke_nickname == 'da'
+
+
+def test_stroke_nickname_defaults_da():
+    a = Articulation({'stroke': 'd'})
+    assert a.stroke_nickname == 'da'
+    assert a.name == 'pluck'
+    assert a.stroke == 'd'
+    assert a.hindi is None
+    assert a.ipa is None
+    assert a.eng_trans is None
+
+
+def test_stroke_nickname_defaults_da_duplicate():
+    a = Articulation({'stroke': 'd'})
+    assert a.stroke_nickname == 'da'
+    assert a.name == 'pluck'
+    assert a.stroke == 'd'
+    assert a.hindi is None
+    assert a.ipa is None
+    assert a.eng_trans is None
+
+
+def test_stroke_r_sets_stroke_nickname():
+    a = Articulation({'stroke': 'r'})
+    assert a.stroke_nickname == 'ra'
+
+
+def test_stroke_r_from_json_sets_stroke_nickname():
+    obj = {'name': 'pluck', 'stroke': 'r'}
+    a = Articulation.from_json(obj)
+    assert a.stroke_nickname == 'ra'


### PR DESCRIPTION
## Summary
- port Articulation model to Python
- implement local humps.decamelize helper
- add tests for Articulation mirroring TS tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed004fcf0832e9f5cd37087dcc6e8