### PR TITLE
Port articulation class to Python

### DIFF
--- a/python/api/classes/articulation.py
+++ b/python/api/classes/articulation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from typing import Optional, TypedDict, Dict
+
+try:
+    import humps
+    decamelize = humps.decamelize  # type: ignore
+except Exception:
+    import re
+    def decamelize(obj: Dict) -> Dict:
+        if isinstance(obj, dict):
+            out: Dict = {}
+            for k, v in obj.items():
+                s = re.sub(r'(?<!^)(?=[A-Z])', '_', k).lower()
+                out[s] = decamelize(v) if isinstance(v, dict) else v
+            return out
+        return obj
+
+class ArticulationOptions(TypedDict, total=False):
+    name: str
+    stroke: str
+    hindi: str
+    ipa: str
+    eng_trans: str
+    stroke_nickname: str
+
+class Articulation:
+    def __init__(self, options: Optional[ArticulationOptions] = None) -> None:
+        opts = decamelize(options or {})
+        self.name: str = opts.get('name', 'pluck')
+        stroke = opts.get('stroke')
+        hindi = opts.get('hindi')
+        ipa = opts.get('ipa')
+        eng_trans = opts.get('eng_trans')
+        stroke_nickname = opts.get('stroke_nickname')
+
+        if stroke is not None:
+            self.stroke = stroke
+        if hindi is not None:
+            self.hindi = hindi
+        if ipa is not None:
+            self.ipa = ipa
+        if eng_trans is not None:
+            self.eng_trans = eng_trans
+        if stroke_nickname is not None:
+            self.stroke_nickname = stroke_nickname
+
+        if getattr(self, 'stroke', None) == 'd' and not hasattr(self, 'stroke_nickname'):
+            self.stroke_nickname = 'da'
+        elif getattr(self, 'stroke', None) == 'r' and not hasattr(self, 'stroke_nickname'):
+            self.stroke_nickname = 'ra'
+
+    @staticmethod
+    def from_json(obj: Dict) -> 'Articulation':
+        return Articulation(obj)

--- a/python/api/tests/articulation_test.py
+++ b/python/api/tests/articulation_test.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from python.api.classes.articulation import Articulation
+
+# Tests mirror src/js/tests/articulation.test.ts
+
+def test_default_articulation():
+    a = Articulation()
+    assert isinstance(a, Articulation)
+    assert a.name == 'pluck'
+    assert getattr(a, 'stroke', None) is None
+    assert getattr(a, 'hindi', None) is None
+    assert getattr(a, 'ipa', None) is None
+    assert getattr(a, 'eng_trans', None) is None
+
+
+def test_articulation_from_json():
+    obj = {
+        'name': 'pluck',
+        'stroke': 'd',
+        'hindi': '\u0926',
+        'ipa': 'd\u032a',
+        'engTrans': 'da',
+        'strokeNickname': 'da'
+    }
+    a = Articulation.from_json(obj)
+    assert a.stroke == 'd'
+    assert a.stroke_nickname == 'da'
+
+
+def test_stroke_nickname_defaults_da_for_d():
+    a = Articulation({'stroke': 'd'})
+    assert a.stroke_nickname == 'da'
+    assert a.name == 'pluck'
+    assert a.stroke == 'd'
+    assert not hasattr(a, 'hindi')
+    assert not hasattr(a, 'ipa')
+    assert not hasattr(a, 'eng_trans')
+
+
+def test_stroke_nickname_defaults_da_for_d_duplicate():
+    a = Articulation({'stroke': 'd'})
+    assert a.stroke_nickname == 'da'
+    assert a.name == 'pluck'
+    assert a.stroke == 'd'
+    assert not hasattr(a, 'hindi')
+    assert not hasattr(a, 'ipa')
+    assert not hasattr(a, 'eng_trans')
+
+
+def test_stroke_r_sets_nickname():
+    a = Articulation({'stroke': 'r'})
+    assert a.stroke_nickname == 'ra'
+
+
+def test_stroke_r_from_json_sets_nickname():
+    obj = {'name': 'pluck', 'stroke': 'r'}
+    a = Articulation.from_json(obj)
+    assert a.stroke_nickname == 'ra'
+


### PR DESCRIPTION
## Summary
- port `articulation.ts` to `python/api/classes/articulation.py`
- add matching unit tests in `python/api/tests/articulation_test.py`
- ensure all Python tests pass

## Testing
- `python -m pytest python/api/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685edec68468832eba9f2475cdd96c7d