### PR TITLE
Add Section class and tests

### DIFF
--- a/python/api/classes/piece.py
+++ b/python/api/classes/piece.py
@@ -1,8 +1,59 @@
 from __future__ import annotations
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Union
 
 from .phrase import Phrase
 from .trajectory import Trajectory
+
+
+SecCatType = Dict[str, Union[Dict[str, bool], str]]
+
+
+def init_sec_categorization() -> SecCatType:
+    return {
+        "Pre-Chiz Alap": {
+            "Pre-Chiz Alap": False,
+        },
+        "Alap": {
+            "Alap": False,
+            "Jor": False,
+            "Alap-Jhala": False,
+        },
+        "Composition Type": {
+            "Dhrupad": False,
+            "Bandish": False,
+            "Thumri": False,
+            "Ghazal": False,
+            "Qawwali": False,
+            "Dhun": False,
+            "Tappa": False,
+            "Bhajan": False,
+            "Kirtan": False,
+            "Kriti": False,
+            "Masitkhani Gat": False,
+            "Razakhani Gat": False,
+            "Ferozkhani Gat": False,
+        },
+        "Comp.-section/Tempo": {
+            "Ati Vilambit": False,
+            "Vilambit": False,
+            "Madhya": False,
+            "Drut": False,
+            "Ati Drut": False,
+            "Jhala": False,
+        },
+        "Tala": {
+            "Ektal": False,
+            "Tintal": False,
+            "Rupak": False,
+        },
+        "Improvisation": {
+            "Improvisation": False,
+        },
+        "Other": {
+            "Other": False,
+        },
+        "Top Level": "None",
+    }
 from .raga import Raga
 from ..enums import Instrument
 

--- a/python/api/classes/section.py
+++ b/python/api/classes/section.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .phrase import Phrase
+from .pitch import Pitch
+from .trajectory import Trajectory
+from .piece import init_sec_categorization, SecCatType
+from .raga import TuningType
+
+
+class Section:
+    def __init__(self, options: Optional[dict] = None) -> None:
+        opts = options or {}
+        self.phrases: List[Phrase] = opts.get('phrases', [])
+
+        categorization = opts.get('categorization')
+        if categorization is not None:
+            self.categorization: SecCatType = categorization
+        else:
+            self.categorization = init_sec_categorization()
+
+        ad_hoc = opts.get('ad_hoc_categorization')
+        if ad_hoc is not None:
+            self.ad_hoc_categorization: List[str] = ad_hoc
+        else:
+            self.ad_hoc_categorization = []
+
+    # ------------------------------------------------------------------
+    def all_pitches(self, repetition: bool = True) -> List[Pitch]:
+        pitches: List[Pitch] = []
+        for phrase in self.phrases:
+            pitches.extend(phrase.all_pitches(True))
+
+        if not repetition:
+            out: List[Pitch] = []
+            for p in pitches:
+                if not out:
+                    out.append(p)
+                else:
+                    prev = out[-1]
+                    if not (
+                        p.swara == prev.swara
+                        and p.oct == prev.oct
+                        and p.raised == prev.raised
+                    ):
+                        out.append(p)
+            return out
+        return pitches
+
+    # ------------------------------------------------------------------
+    @property
+    def trajectories(self) -> List[Trajectory]:
+        trajs: List[Trajectory] = []
+        for phrase in self.phrases:
+            trajs.extend(phrase.trajectories)
+        return trajs
+
+
+et_tuning: TuningType = {
+    'sa': 2 ** (0 / 12),
+    're': {
+        'lowered': 2 ** (1 / 12),
+        'raised': 2 ** (2 / 12),
+    },
+    'ga': {
+        'lowered': 2 ** (3 / 12),
+        'raised': 2 ** (4 / 12),
+    },
+    'ma': {
+        'lowered': 2 ** (5 / 12),
+        'raised': 2 ** (6 / 12),
+    },
+    'pa': 2 ** (7 / 12),
+    'dha': {
+        'lowered': 2 ** (8 / 12),
+        'raised': 2 ** (9 / 12),
+    },
+    'ni': {
+        'lowered': 2 ** (10 / 12),
+        'raised': 2 ** (11 / 12),
+    },
+}
+

--- a/python/api/tests/section_test.py
+++ b/python/api/tests/section_test.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from python.api.classes.section import Section
+from python.api.classes.phrase import Phrase
+from python.api.classes.trajectory import Trajectory
+from python.api.classes.pitch import Pitch
+
+
+# Tests mirror src/ts/tests/section.test.ts
+
+
+def test_section_aggregates():
+    p1 = Phrase({'trajectories': [Trajectory()]})
+    p2 = Phrase({'trajectories': [Trajectory()]})
+    sec = Section({'phrases': [p1, p2]})
+    assert len(sec.trajectories) == 2
+    assert len(sec.all_pitches()) == 2
+
+
+def test_section_all_pitches_and_trajectories_getters():
+    sa1 = Trajectory({'pitches': [Pitch({'swara': 'sa'})]})
+    sa2 = Trajectory({'pitches': [Pitch({'swara': 'sa'})]})
+    re = Trajectory({'pitches': [Pitch({'swara': 're'})]})
+
+    p1 = Phrase({'trajectories': [sa1, sa2]})
+    p2 = Phrase({'trajectories': [re]})
+    sec = Section({'phrases': [p1, p2]})
+
+    assert len(sec.all_pitches(False)) == 2
+    assert sec.trajectories == [sa1, sa2, re]
+


### PR DESCRIPTION
## Summary
- port `section.ts` logic to new `section.py`
- add `init_sec_categorization` helper to `piece.py`
- add tests mirroring `section.test.ts`

## Testing
- `pytest -q python/api/tests/section_test.py`
- `pytest -q python/api/tests`

------
https://chatgpt.com/codex/tasks/task_e_685ef0549d58832e9a9fb26e9f594e14