### PR TITLE
fix: rebuild extract.js for phrase-based section tracking and add backup docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,4 +368,112 @@ pnpm deployShared       # Deploy shared TypeScript types (manual)
 - User-uploaded file management
 - Temporary file cleanup
 
-This architecture provides a sophisticated platform for musical transcription and analysis, balancing research-grade analytical capabilities with intuitive user interfaces for both academic and practical applications. The polyphonic individual instrumentality system enables detailed study of complex Indian classical music performances, while the Python API integration facilitates computational musicology research and institutional data access. The platform continues to evolve with automated development workflows and comprehensive security measures to support both individual musicians and academic research communities.
+## Database Backup and Restoration
+
+### Backup System
+IDTAP maintains daily MongoDB backups on the production server at `/root/backups/` with the following structure:
+```
+/root/backups/
+├── YYYY-M-D/           # Daily backup directories (e.g., 2023-9-15)
+│   └── swara/          # Database backup files
+│       ├── transcriptions.bson
+│       ├── transcriptions.metadata.json
+│       ├── audioFiles.bson
+│       ├── users.bson
+│       └── [other collections...]
+└── backup_mongo.py     # Automated backup script
+```
+
+**Backup Script**: `/root/backups/backup_mongo.py` runs daily to create MongoDB dumps using `mongodump`.
+
+### Restoration Process
+
+#### 1. **Exploring Backups**
+```bash
+# SSH into production server
+ssh root@137.184.90.119
+
+# List available backup dates
+ls /root/backups/ | grep YYYY
+
+# Check backup contents
+ls -la /root/backups/2023-9-15/swara/
+
+# Examine BSON files (search for specific documents)
+bsondump /root/backups/2023-9-15/swara/transcriptions.bson | grep "search_term"
+```
+
+#### 2. **Full Database Restoration**
+```bash
+# Restore entire backup to a test database (RECOMMENDED)
+mongorestore --uri 'mongodb+srv://export_robot:PASSWORD@swara.f5cuf.mongodb.net/test_restore_YYYY_MM_DD' \
+             --drop /root/backups/YYYY-M-D/swara/
+
+# Restore to production database (USE WITH CAUTION)
+mongorestore --uri 'mongodb+srv://export_robot:PASSWORD@swara.f5cuf.mongodb.net/swara' \
+             --drop /root/backups/YYYY-M-D/swara/
+```
+
+#### 3. **Single Document Recovery**
+```bash
+# Export specific document from backup
+mongoexport --uri 'mongodb+srv://export_robot:PASSWORD@swara.f5cuf.mongodb.net/test_restore_DB' \
+            --collection transcriptions \
+            --query '{"_id": {"$oid": "DOCUMENT_ID"}}' \
+            --out /root/specific_document.json
+
+# Import to live database
+mongoimport --uri 'mongodb+srv://export_robot:PASSWORD@swara.f5cuf.mongodb.net/swara' \
+            --collection transcriptions \
+            --file /root/specific_document.json \
+            --upsert
+```
+
+#### 4. **Finding Lost Data**
+**Search for documents across multiple backup dates:**
+```bash
+# Search for document ID across multiple backups
+for backup in /root/backups/2023-*/swara/; do
+    echo "Checking $backup"
+    bsondump "$backup/transcriptions.bson" 2>/dev/null | grep "DOCUMENT_ID" && echo "Found in $backup"
+done
+
+# Search by content (e.g., title, creator)
+bsondump /root/backups/2023-9-15/swara/transcriptions.bson | grep -E '"title".*"search_term"|"createdBy".*"Name"'
+```
+
+#### 5. **Permission Field Evolution**
+IDTAP's permission system has evolved:
+- **Legacy**: `"permissions": "Public"` (string field)
+- **Current**: `"explicitPermissions": {"edit":["userId"], "view":[], "publicView":true}` (object field)
+
+When restoring older transcriptions, you may need to migrate permissions:
+```javascript
+// Example permission migration
+{
+  "permissions": "Public"  // Old format
+}
+// becomes:
+{
+  "explicitPermissions": {
+    "edit": [],
+    "view": [],
+    "publicView": true
+  }
+}
+```
+
+### Best Practices
+1. **Always test with a separate database first**: Use `test_restore_YYYY_MM_DD` naming
+2. **Verify data in MongoDB Atlas web interface** before applying to production
+3. **Document the restoration**: Note which backup date was used and why
+4. **Check for schema changes**: Newer fields like `explicitPermissions` may not exist in older backups
+5. **Coordinate with team**: Ensure no one is actively editing during restoration
+
+### Backup Retention
+- **Daily backups**: Maintained automatically going back several years
+- **Storage**: Local server storage at `/root/backups/`
+- **Format**: MongoDB BSON dumps with metadata JSON files
+- **Collections**: All database collections backed up daily
+
+This backup system ensures data recovery capabilities and supports research workflows requiring access to historical transcription data.

--- a/server/extract.js
+++ b/server/extract.js
@@ -69434,6 +69434,7 @@ var Phrase = class _Phrase {
   categorizationGrid;
   adHocCategorizationGrid;
   uniqueId;
+  isSectionStart;
   constructor({
     trajectories = [],
     durTot = void 0,
@@ -69447,7 +69448,8 @@ var Phrase = class _Phrase {
     groupsGrid = void 0,
     categorizationGrid = void 0,
     uniqueId = void 0,
-    adHocCategorizationGrid = void 0
+    adHocCategorizationGrid = void 0,
+    isSectionStart = void 0
   } = {}) {
     if (uniqueId === void 0) {
       this.uniqueId = v4_default();
@@ -69521,6 +69523,7 @@ var Phrase = class _Phrase {
     } else {
       this.adHocCategorizationGrid = [];
     }
+    this.isSectionStart = isSectionStart;
   }
   updateFundamental(fundamental) {
     this.trajectories.forEach((traj) => traj.updateFundamental(fundamental));
@@ -69881,7 +69884,8 @@ var Phrase = class _Phrase {
       groupsGrid: this.groupsGrid,
       categorizationGrid: this.categorizationGrid,
       uniqueId: this.uniqueId,
-      adHocCategorizationGrid: this.adHocCategorizationGrid
+      adHocCategorizationGrid: this.adHocCategorizationGrid,
+      isSectionStart: this.isSectionStart
     };
   }
   static fromJSON(obj2) {
@@ -72248,7 +72252,8 @@ var Piece = class _Piece {
   soloInstrument;
   phraseGrid;
   durArrayGrid;
-  sectionStartsGrid;
+  _sectionStartsGrid;
+  // Legacy storage for migration
   sectionCatGrid;
   excerptRange;
   adHocSectionCatGrid;
@@ -72307,16 +72312,15 @@ var Piece = class _Piece {
     this.durArrayGrid.length = instrumentation.length;
     if (sectionStartsGrid !== void 0) {
       this.sectionStartsGrid = sectionStartsGrid;
+    } else if (sectionStarts !== void 0) {
+      this.sectionStartsGrid = [sectionStarts];
     } else {
-      this.sectionStartsGrid = sectionStarts === void 0 ? [[0]] : [sectionStarts];
+      this.phraseGrid.forEach((phrases2, trackIdx) => {
+        if (phrases2.length > 0 && phrases2[0]) {
+          phrases2[0].isSectionStart = true;
+        }
+      });
     }
-    for (let i = 1; i < instrumentation.length; i++) {
-      this.sectionStartsGrid.push([0]);
-    }
-    this.sectionStartsGrid.length = instrumentation.length;
-    this.sectionStartsGrid.forEach((ss, i) => {
-      ss.sort((a, b) => a - b);
-    });
     if (sectionCatGrid !== void 0) {
       this.sectionCatGrid = sectionCatGrid;
       if (this.sectionCatGrid.length === 0) {
@@ -72476,6 +72480,22 @@ var Piece = class _Piece {
   }
   set durArray(arr) {
     this.durArrayGrid[0] = arr;
+  }
+  // Computed property that derives section starts from phrase properties
+  get sectionStartsGrid() {
+    return this.phraseGrid.map(
+      (phrases) => phrases.map((p, idx) => ({ phrase: p, idx })).filter(({ phrase }) => phrase.isSectionStart).map(({ idx }) => idx)
+    );
+  }
+  // Setter for backward compatibility during migration
+  set sectionStartsGrid(grid) {
+    grid.forEach((sectionIndices, trackIdx) => {
+      if (this.phraseGrid[trackIdx]) {
+        this.phraseGrid[trackIdx].forEach((phrase, pIdx) => {
+          phrase.isSectionStart = sectionIndices.includes(pIdx);
+        });
+      }
+    });
   }
   get sectionStarts() {
     return this.sectionStartsGrid[0];
@@ -73268,8 +73288,9 @@ var Piece = class _Piece {
       name: this.name,
       family_name: this.family_name,
       given_name: this.given_name,
-      sectionStarts: this.sectionStarts,
+      // sectionStarts: removed - now computed from phrase.isSectionStart
       instrumentation: this.instrumentation,
+      trackTitles: this.trackTitles,
       meters: this.meters,
       sectionCategorization: this.sectionCategorization,
       explicitPermissions: this.explicitPermissions,
@@ -73277,7 +73298,7 @@ var Piece = class _Piece {
       soloInstrument: this.soloInstrument,
       phraseGrid: this.phraseGrid,
       durArrayGrid: this.durArrayGrid,
-      sectionStartsGrid: this.sectionStartsGrid,
+      // sectionStartsGrid: removed - now computed from phrase.isSectionStart
       sectionCatGrid: this.sectionCatGrid,
       excerptRange: this.excerptRange,
       adHocSectionCatGrid: this.adHocSectionCatGrid,
@@ -73296,6 +73317,16 @@ var Piece = class _Piece {
     obj2.phraseGrid = (obj2.phraseGrid || []).map((phrases, instIdx) => {
       return phrases.map((p) => Phrase.fromJSON(p));
     });
+    if (obj2.sectionStartsGrid && Array.isArray(obj2.sectionStartsGrid)) {
+      obj2.phraseGrid.forEach((phrases, trackIdx) => {
+        const sectionIndices = obj2.sectionStartsGrid[trackIdx] || [];
+        phrases.forEach((phrase, pIdx) => {
+          if (phrase.isSectionStart === void 0) {
+            phrase.isSectionStart = sectionIndices.includes(pIdx);
+          }
+        });
+      });
+    }
     if (obj2.meters) {
       obj2.meters = obj2.meters.map((m) => new Meter(m));
     }
@@ -73333,7 +73364,6 @@ var Piece = class _Piece {
       });
     });
     piece.durArrayFromPhrases();
-    piece.sectionStartsGrid = piece.sectionStartsGrid.map((arr) => [...new Set(arr)]);
     piece.ensureStringSynchronization();
     return piece;
   }


### PR DESCRIPTION
## Summary
- Rebuild missing `extract.js` bundle from PR #847's TypeScript changes
- Add comprehensive database backup/restoration documentation to CLAUDE.md

## Background
PR #847 introduced the `isSectionStart` property to `Phrase` and converted `sectionStartsGrid` to a computed property in the TypeScript source files (`src/ts/model/phrase.ts` and `src/ts/model/piece.ts`). However, the bundled `server/extract.js` file was never rebuilt, causing:
- Data export issues when using the Python API
- Inconsistency between client and server data models

## Changes

### `server/extract.js`
Rebuilt from TypeScript sources using `pnpm buildExtract`, adding:
- `isSectionStart` property to `Phrase` class
- Computed `sectionStartsGrid` getter/setter for backward compatibility
- Migration logic from legacy `sectionStartsGrid` arrays
- Removal of `sectionStartsGrid` from serialization output

### `CLAUDE.md`
Added new "Database Backup and Restoration" section with:
- Daily backup structure documentation (`/root/backups/`)
- Full database restoration procedures
- Single document recovery workflows
- Search techniques for finding lost data
- Permission field evolution notes (legacy vs current format)
- Best practices for safe restoration

## Test plan
- [x] Rebuild `extract.js` produces identical output to committed version
- [x] Verify TypeScript sources match bundled output
- [ ] Test data export with Python API to confirm no errors
- [ ] Verify transcription save/load still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)