### PR TITLE
fix: clean up metronome audio nodes to prevent audio engine overflow

### DIFF
--- a/src/synths/woodblock.ts
+++ b/src/synths/woodblock.ts
@@ -4,7 +4,10 @@ export class WoodblockSynth {
 	osc2: OscillatorNode;
 	mixNode: GainNode;
 	envNode: GainNode;
-	
+	// Track scheduled noise nodes for cleanup
+	private scheduledNoiseSources: AudioBufferSourceNode[] = [];
+	private scheduledNoiseGains: GainNode[] = [];
+
 	constructor(ac: AudioContext, destination: AudioNode) {
 		this.ac = ac;
 		// create nodes
@@ -61,6 +64,10 @@ export class WoodblockSynth {
 
     noiseSrc.start(when);
     noiseSrc.stop(when + dur + 0.01);
+
+    // Track for cleanup
+    this.scheduledNoiseSources.push(noiseSrc);
+    this.scheduledNoiseGains.push(depth);
   }
 
 	scheduleAttack(when: number, freq: number, amp: number) {
@@ -89,6 +96,25 @@ export class WoodblockSynth {
     this.envNode.gain.setValueAtTime(0, t);
     this.osc1.frequency.cancelScheduledValues(t);
     this.osc2.frequency.cancelScheduledValues(t);
+
+    // Clean up all scheduled noise nodes
+    for (const src of this.scheduledNoiseSources) {
+      try {
+        src.stop();
+        src.disconnect();
+      } catch (e) {
+        // Ignore errors from already-stopped sources
+      }
+    }
+    for (const gain of this.scheduledNoiseGains) {
+      try {
+        gain.disconnect();
+      } catch (e) {
+        // Ignore errors from already-disconnected nodes
+      }
+    }
+    this.scheduledNoiseSources = [];
+    this.scheduledNoiseGains = [];
   }
 
 }


### PR DESCRIPTION
## Summary
- Fix audio engine getting overwhelmed after repeated play/stop cycles
- The WoodblockSynth was leaking AudioBufferSourceNode and GainNode instances

## Problem
Every metronome beat scheduled via `scheduleAttack()` created new audio nodes in the `noiseFM()` method that were never cleaned up. For a piece with many pulses, each play/stop cycle could create hundreds of orphaned nodes still connected to the audio graph, eventually overwhelming the Web Audio API and causing all audio to stop.

## Solution
- Track all created noise source and gain nodes in arrays
- Stop and disconnect all tracked nodes when `cancelScheduled()` is called
- Clear tracking arrays after cleanup

## Test plan
- [x] Build succeeds
- [x] Manual testing: play/stop repeatedly with metronome enabled, audio continues working

🤖 Generated with [Claude Code](https://claude.com/claude-code)