### PR TITLE
fix: add phrase/vibhag labels to display settings and fix vibhag drift

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -942,6 +942,8 @@ type DisplaySettings = {
     meter: boolean,
     phonemes: boolean,
     phraseDivs: boolean,
+    phraseLabels: boolean,
+    vibhagLabels: boolean,
   }
 }
 

--- a/src/comps/editor/audioPlayer/SpectrogramControls.vue
+++ b/src/comps/editor/audioPlayer/SpectrogramControls.vue
@@ -653,6 +653,19 @@ export default defineComponent({
       "uniqueId": "ffa38001-f592-4778-a91e-c4ef5c99b081",
       "scaleSystem": ScaleSystem.Sargam,
       "timingDisplay": TimingDisplay.ExcerptTime,
+      "visibility": {
+        "spectrogram": true,
+        "melograph": true,
+        "sargam": true,
+        "sargamLines": true,
+        "bols": true,
+        "transcription": true,
+        "meter": true,
+        "phonemes": true,
+        "phraseDivs": true,
+        "phraseLabels": true,
+        "vibhagLabels": false,
+      },
     } as DisplaySettings;
 
     const intensityPower = ref(1);
@@ -1119,7 +1132,9 @@ export default defineComponent({
         transcription: transcriptionToggleProxy.value,
         meter: meterToggleProxy.value,
         phonemes: phonemesToggleProxy.value,
-        phraseDivs: phraseDivsToggleProxy.value
+        phraseDivs: phraseDivsToggleProxy.value,
+        phraseLabels: phraseLabelsToggleProxy.value,
+        vibhagLabels: vibhagLabelsToggleProxy.value,
       }
       const uId = id ? id : uuidv4();
       return {
@@ -1212,6 +1227,12 @@ export default defineComponent({
         meterToggleProxy.value = s.visibility.meter;
         phonemesToggleProxy.value = s.visibility.phonemes;
         phraseDivsToggleProxy.value = s.visibility.phraseDivs;
+        if (s.visibility.phraseLabels !== undefined) {
+          phraseLabelsToggleProxy.value = s.visibility.phraseLabels;
+        }
+        if (s.visibility.vibhagLabels !== undefined) {
+          vibhagLabelsToggleProxy.value = s.visibility.vibhagLabels;
+        }
       }
       updateIntensityAndColorMap();
 

--- a/src/comps/editor/renderer/XAxis.vue
+++ b/src/comps/editor/renderer/XAxis.vue
@@ -387,16 +387,14 @@ export default defineComponent({
 
         // Repeat vibhaga labels for each cycle
         for (let rep = 0; rep < meter.repetitions; rep++) {
-          const cycleStartTime = meter.startTime + (rep * meter.cycleDur);
-
           // Draw labels for each vibhag in this cycle
           for (let vibhagIdx = 0; vibhagIdx < vibhagCount; vibhagIdx++) {
             const vibhagLabel = meter.vibhaga[vibhagIdx];
-            const ps = topLayerStructures[vibhagIdx];
+            // Index into topLayerStructures accounts for cycle number
+            const ps = topLayerStructures[rep * vibhagCount + vibhagIdx];
 
-            // Calculate the time for this vibhag in this repetition
-            const vibhagTimeInCycle = ps.pulses[0].realTime - meter.startTime;
-            const pulseTime = cycleStartTime + vibhagTimeInCycle;
+            // Use the pulse's absolute time directly
+            const pulseTime = ps.pulses[0].realTime;
             const xPos = props.scale(pulseTime);
 
             // Vibhaga label positioned at the pulse time


### PR DESCRIPTION
## Summary
- Add `phraseLabels` and `vibhagLabels` visibility options to the Display Settings save/load system
- Fix vibhag label positioning drift in multi-cycle tala meters

## Changes

### Display Settings Enhancement
- Added `phraseLabels` and `vibhagLabels` to `DisplaySettings` visibility type in `shared/types.ts`
- Added full visibility object to `defaultSetting` with `phraseLabels: true` and `vibhagLabels: false`
- Updated `getDisplaySettings()` to include the new visibility properties
- Updated `loadSetting()` with backward-compatible restoration of new properties

### Vibhag Drift Fix
- Fixed bug where vibhag markers displayed correctly in the first tala cycle but drifted progressively left in subsequent cycles
- Root cause: `topLayerStructures[vibhagIdx]` always accessed indices 0-3 regardless of cycle number
- Fix: Changed index to `topLayerStructures[rep * vibhagCount + vibhagIdx]` to access correct pulse structures per cycle

## Test plan
- [ ] Save display settings with different phrase/vibhag label visibility combinations
- [ ] Load saved settings and verify phrase/vibhag label visibility is restored correctly
- [ ] Open a transcription with multiple tala cycles and verify vibhag labels are correctly positioned in all cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)