### PR TITLE
fix: only exit serial mode when next trajectory is melodic

### DIFF
--- a/src/comps/editor/EditorComponent.vue
+++ b/src/comps/editor/EditorComponent.vue
@@ -2026,9 +2026,35 @@ export default defineComponent({
           throw new Error('Trajectory index not found')
         }
 
-        // Check if continuation point is on a melodic trajectory (not silence)
+        // Check if continuation point leads into a melodic trajectory (not silence)
         const continuationTraj = phrase.trajectoryGrid[stringIdx][tIdx];
+        const continuationTime = this.trajTimePts[0].time;
+        const phraseTime = continuationTime - phrase.startTime!;
+
+        let shouldExitSerialMode = false;
+
         if (continuationTraj && continuationTraj.id !== 12) {
+          // We landed on a melodic trajectory. Check if we're at its end boundary
+          // (meaning we're actually at the start of the next trajectory)
+          const trajEnd = continuationTraj.startTime! + continuationTraj.durTot;
+          const epsilon = 0.02;
+          const atMelodicEnd = Math.abs(phraseTime - trajEnd) < epsilon;
+
+          if (atMelodicEnd) {
+            // At end of melodic - check if next trajectory is silence
+            if (tIdx + 1 < phrase.trajectoryGrid[stringIdx].length) {
+              const nextTraj = phrase.trajectoryGrid[stringIdx][tIdx + 1];
+              shouldExitSerialMode = nextTraj.id !== 12; // Exit only if next is also melodic
+            } else {
+              shouldExitSerialMode = true; // No more trajectories
+            }
+          } else {
+            // In middle of melodic trajectory (shouldn't happen normally)
+            shouldExitSerialMode = true;
+          }
+        }
+
+        if (shouldExitSerialMode) {
           // Exit serial mode - no continuation into melodic trajectory
           this.selectedMode = EditorMode.None;
           this.trajTimePts = [];


### PR DESCRIPTION
## Summary
Follow-up fix to PR #873. The previous fix was exiting serial mode prematurely when the continuation point landed on the melodic trajectory we just created.

## Problem
After creating a trajectory in serial mode, `trajIdxFromTime` would return the melodic trajectory we just created (because the continuation time equals its end time). The previous logic would see this melodic trajectory and exit serial mode, even when there was silence ahead to continue into.

## Fix
When the continuation point lands on a melodic trajectory:
1. Check if we're at its END boundary (not in the middle)
2. If at the end, look at the NEXT trajectory in the grid
3. Only exit serial mode if the next trajectory is also melodic (or no more trajectories)
4. Continue serial mode normally if the next trajectory is silence

## Test plan
- [ ] In serial mode, create trajectory ending in silence - should continue showing drag dot
- [ ] In serial mode, create trajectory ending at another melodic trajectory - should exit serial mode
- [ ] Verify normal serial mode workflow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)