### PR TITLE
feat: snap region selection to meter pulses

### DIFF
--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -6493,8 +6493,13 @@ export default defineComponent({
         } else {
           regionEndPxl.value = e.x;
         }
-        // Apply meter magnetization to end position before drawing
+        // Apply meter magnetization to both positions before drawing
         if (props.meterMagnetMode) {
+          const startTime = props.xScale.invert(regionStartPxl.value);
+          const snappedStartTime = meterMagnetize(startTime);
+          if (snappedStartTime !== startTime) {
+            regionStartPxl.value = props.xScale(snappedStartTime);
+          }
           const endTime = props.xScale.invert(regionEndPxl.value);
           const snappedEndTime = meterMagnetize(endTime);
           if (snappedEndTime !== endTime) {
@@ -6508,9 +6513,10 @@ export default defineComponent({
           regionEndPxl.value = undefined;
         } else {
           setUpRegion();
+          emit('update:regionStartPxl', regionStartPxl.value)
           emit('update:regionEndPxl', regionEndPxl.value)
         }
-        
+
       } else {
         const c = selBoxStartX === e.x && selBoxStartY === e.y;
         if (selBoxStartX !== undefined && selBoxStartY !== undefined && !c) {


### PR DESCRIPTION
## Summary
When creating a region via X-axis drag or Option+drag on the graph, if meter magnet mode is enabled and the region endpoints are within a meter, they now snap to the nearest meter pulse.

## Implementation
- Modified the `regionStartPxl` and `regionEndPxl` watchers in TranscriptionLayer.vue to apply snapping
- Added inline meter magnetization in the `selBoxDragEnd` handler for Option+drag (Vue watchers are async, so snapping needs to happen before `setUpRegion()`)
- Emit snapped pixel values to XAxis so its region lines display at the correct positions
- Handle both left-to-right and right-to-left drag directions

## Commits
1. **feat**: Initial implementation - snap region in watchers
2. **fix**: Emit snapped values to update XAxis display
3. **fix**: Emit snapped regionEndPxl value in Option+drag
4. **fix**: Apply meter snap inline in dragEnd before drawing region
5. **fix**: Snap both region start and end in Option+drag (handles right-to-left drag)

## Test plan
- [x] Enable meter magnet mode
- [x] Drag on X-axis to create region near meter pulses - snaps to pulses
- [x] Option+drag on graph (left to right) - snaps both ends
- [x] Option+drag on graph (right to left) - snaps both ends
- [x] XAxis region lines display at snapped positions
- [x] Transcription layer region displays at snapped positions
- [ ] Disable meter magnet mode - should NOT snap (original behavior)
- [ ] Create region outside meter range - should NOT snap even with meter magnet on

🤖 Generated with [Claude Code](https://claude.com/claude-code)