### PR TITLE
feat: snap drag dot arrow key nudge to meter pulses

### DIFF
--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -6031,7 +6031,17 @@ export default defineComponent({
       let newLogFreq = traj.logFreqs.length > idx ? traj.logFreqs[idx] : 
         traj.logFreqs[idx - 1];
       if (dir === 'left') {
-        newTime = constrainTime(curTime - amt, idx);
+        // If meter magnet mode is on, move to previous pulse instead of fixed amount
+        if (props.meterMagnetMode) {
+          const prevPulse = getAdjacentMeterPulse(curTime, 'left');
+          if (prevPulse !== undefined) {
+            newTime = constrainTime(prevPulse, idx);
+          } else {
+            newTime = constrainTime(curTime - amt, idx);
+          }
+        } else {
+          newTime = constrainTime(curTime - amt, idx);
+        }
         const x = props.xScale(newTime);
         d3.select(`#dragDot${traj.uniqueId}_${idx}`)
           .attr('cx', x);
@@ -6063,7 +6073,17 @@ export default defineComponent({
           }
         }
       } else if (dir === 'right') {
-        newTime = constrainTime(curTime + amt, idx);
+        // If meter magnet mode is on, move to next pulse instead of fixed amount
+        if (props.meterMagnetMode) {
+          const nextPulse = getAdjacentMeterPulse(curTime, 'right');
+          if (nextPulse !== undefined) {
+            newTime = constrainTime(nextPulse, idx);
+          } else {
+            newTime = constrainTime(curTime + amt, idx);
+          }
+        } else {
+          newTime = constrainTime(curTime + amt, idx);
+        }
         const x = props.xScale(newTime);
         d3.select(`#dragDot${traj.uniqueId}_${idx}`)
           .attr('cx', x);
@@ -6844,6 +6864,36 @@ export default defineComponent({
         outTime = time
       }
       return outTime
+    };
+
+    // Find the next or previous meter pulse from the given time
+    const getAdjacentMeterPulse = (time: number, direction: 'left' | 'right'): number | undefined => {
+      let result: number | undefined = undefined;
+      const epsilon = 1e-6; // Small tolerance for "at pulse" detection
+      props.piece.meters.forEach(meter => {
+        const corpTimes = meter.realCorpTimes;
+        const start = corpTimes[0];
+        const end = corpTimes[corpTimes.length - 1];
+        if (time >= start - epsilon && time <= end + epsilon) {
+          if (direction === 'right') {
+            // Find first pulse strictly greater than current time
+            const nextPulse = corpTimes.find(t => t > time + epsilon);
+            if (nextPulse !== undefined && (result === undefined || nextPulse < result)) {
+              result = nextPulse;
+            }
+          } else {
+            // Find last pulse strictly less than current time
+            const prevPulses = corpTimes.filter(t => t < time - epsilon);
+            if (prevPulses.length > 0) {
+              const prevPulse = prevPulses[prevPulses.length - 1];
+              if (result === undefined || prevPulse > result) {
+                result = prevPulse;
+              }
+            }
+          }
+        }
+      });
+      return result;
     };
 
     const insertNewTrajDot = (


### PR DESCRIPTION
## Summary
When meter magnet mode is on and nudging a drag dot with left/right arrow keys, move to the next/previous meter pulse instead of the default fixed amount (0.01s).

## Implementation
- Added `getAdjacentMeterPulse(time, direction)` helper function that finds the next or previous pulse within a meter
- Modified `nudgeDragDot` function to use meter pulses when `meterMagnetMode` is on
- Falls back to the default fixed amount if no pulse is found in that direction (e.g., at meter boundaries)

## Test plan
- [ ] Enable meter magnet mode
- [ ] Select a trajectory and then a drag dot
- [ ] Press left/right arrow keys - should jump to next/previous meter pulse
- [ ] Disable meter magnet mode - should use default 0.01s nudge amount
- [ ] Test at meter boundaries - should fall back to fixed amount if no more pulses

🤖 Generated with [Claude Code](https://claude.com/claude-code)