### PR TITLE
feat: snap playhead double-click to meter pulse

### DIFF
--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -6832,6 +6832,10 @@ export default defineComponent({
 
     const handleDoubleClick = (e: MouseEvent) => {
       let time = props.xScale.invert(e.offsetX);
+      // Snap to meter pulse if meter magnet mode is on
+      if (props.meterMagnetMode) {
+        time = meterMagnetize(time);
+      }
       emit('update:currentTime', time);
 
       updatePlayheadPosition(time);


### PR DESCRIPTION
## Summary
When meter magnet mode is on and double-clicking to move the playhead, snap the position to the nearest meter pulse.

## Implementation
Simple 3-line addition to `handleDoubleClick` function - apply `meterMagnetize()` to the time when `meterMagnetMode` is on.

## Test plan
- [ ] Enable meter magnet mode
- [ ] Double-click on the transcription layer when paused - playhead should snap to nearest meter pulse
- [ ] Disable meter magnet mode - playhead should go to exact click position

🤖 Generated with [Claude Code](https://claude.com/claude-code)