### PR TITLE
feat: raga-derived chikari pitches

### DIFF
--- a/src/audioWorklets/chikaris4.worklet.js
+++ b/src/audioWorklets/chikaris4.worklet.js
@@ -84,18 +84,30 @@ class Processor extends AudioWorkletProcessor {
         this.writePtr2 = 0;
         this.writePtr3 = 0;
         
-        // Initial delay pointers for strum timing
+        // Initial delay pointers for strum timing (configured via port message)
         this.initWritePtr0 = 0;
-        this.initWritePtr1 = (2 ** -8 * sampleRate) & 2047;
-        this.initWritePtr2 = (2 ** -7 * sampleRate) & 2047;
-        this.initWritePtr3 = (2 ** -6 * sampleRate) & 2047;
+        this.initWritePtr1 = 0;
+        this.initWritePtr2 = 0;
+        this.initWritePtr3 = 0;
         this.initReadPtr0 = 0;
         this.initReadPtr1 = 0;
         this.initReadPtr2 = 0;
         this.initReadPtr3 = 0;
-        
+
         // Filter states for each string
         this.y1 = [0, 0, 0, 0];
+
+        // Accept strum delay configuration from application
+        this.port.onmessage = (e) => {
+            if (e.data.type === 'setStrumDelays') {
+                // delays: [samples0, samples1, samples2, samples3]
+                const delays = e.data.delays;
+                this.initWritePtr0 = (this.initReadPtr0 + delays[0]) & 2047;
+                this.initWritePtr1 = (this.initReadPtr1 + delays[1]) & 2047;
+                this.initWritePtr2 = (this.initReadPtr2 + delays[2]) & 2047;
+                this.initWritePtr3 = (this.initReadPtr3 + delays[3]) & 2047;
+            }
+        };
     }
 
     setDelayTime(time0, time1, time2, time3) {

--- a/src/comps/editor/audioPlayer/EditorAudioPlayer.vue
+++ b/src/comps/editor/audioPlayer/EditorAudioPlayer.vue
@@ -1189,20 +1189,21 @@ export default defineComponent({
       const newVal = 2 ** (cents / 1200);
       this.rubberBandNode!.setPitch(newVal);
       const raga = this.piece.raga;
-      const freqs = raga.chikariPitches.map((p) => p.frequency);
+      const pitches = raga.chikariPitches;
       const transp = 2 ** (this.transposition / 1200);
       const synthsComp = this.$refs.synths as InstanceType<typeof Synths>;
       this.instTracks.forEach((track, idx) => {
         if (track.inst === Instrument.Sitar) {
           const nodesObj = synthsComp.synths[idx] as SitarSynthType;
           const chikariNode = nodesObj.chikariNode;
-          const curFreq0 = chikariNode.freq0!.value;
-          const curFreq1 = chikariNode.freq1!.value;
-          chikariNode.freq0!.setValueAtTime(curFreq0, this.now());
-          chikariNode.freq1!.setValueAtTime(curFreq1, this.now());
           const et = this.now() + this.lagTime;
-          chikariNode.freq0!.linearRampToValueAtTime(freqs[0] * transp, et);
-          chikariNode.freq1!.linearRampToValueAtTime(freqs[1] * transp, et);
+          const freqParams = [chikariNode.freq0!, chikariNode.freq1!, chikariNode.freq2!, chikariNode.freq3!];
+          freqParams.forEach((param, i) => {
+            if (pitches[i]) {
+              param.setValueAtTime(param.value, this.now());
+              param.linearRampToValueAtTime(pitches[i]!.frequency * transp, et);
+            }
+          });
         }
       })
     },
@@ -1507,6 +1508,8 @@ export default defineComponent({
               extChikariGain: 1,
               chikariFreq0: this.piece.chikariFreqs(i)[0],
               chikariFreq1: this.piece.chikariFreqs(i)[1],
+              chikariFreq2: this.piece.chikariFreqs(i)[2],
+              chikariFreq3: this.piece.chikariFreqs(i)[3],
             }
           });
         } else if (track.inst === Instrument.Sarangi) {

--- a/src/comps/editor/audioPlayer/Synths.vue
+++ b/src/comps/editor/audioPlayer/Synths.vue
@@ -294,15 +294,32 @@ export default defineComponent({
         chikariLoopSourceNode.loop = true;
         chikariNode.freq0!.value = control.params.chikariFreq0!;
         chikariNode.freq1!.value = control.params.chikariFreq1!;
-        // Set default frequencies for strings 2 and 3 (can be made configurable later)
-        const fundamental = props.piece.raga.fundamental;
-        chikariNode.freq2!.value = fundamental * 2 ** (7/12); // Perfect fifth above fundamental
-        chikariNode.freq3!.value = fundamental * 2 ** (4/12); // Major third above fundamental
-        // All string gains start at 1.0 (full volume)
+        chikariNode.freq2!.value = control.params.chikariFreq2 || 110;
+        chikariNode.freq3!.value = control.params.chikariFreq3 || 110;
         chikariNode.stringGain0!.value = 1.0;
         chikariNode.stringGain1!.value = 1.0;
-        chikariNode.stringGain2!.value = 1.0;
-        chikariNode.stringGain3!.value = 1.0;
+        chikariNode.stringGain2!.value = control.params.chikariFreq2 ? 1.0 : 0;
+        chikariNode.stringGain3!.value = control.params.chikariFreq3 ? 1.0 : 0;
+
+        // Configure strum order: sorted low-to-high by frequency
+        const chikariFreqs = [
+          control.params.chikariFreq0!,
+          control.params.chikariFreq1!,
+          control.params.chikariFreq2 || 0,
+          control.params.chikariFreq3 || 0,
+        ];
+        const strumStep = Math.round(2 ** -9 * props.ac.sampleRate); // ~2ms per string
+        const sortedIndices = chikariFreqs
+          .map((f, i) => ({ freq: f, idx: i }))
+          .filter(e => e.freq > 0)
+          .sort((a, b) => a.freq - b.freq)
+          .map(e => e.idx);
+        const delays = [0, 0, 0, 0];
+        sortedIndices.forEach((strIdx, order) => {
+          delays[strIdx] = strumStep * order;
+        });
+        chikariNode.port.postMessage({ type: 'setStrumDelays', delays });
+
         sonifyNode.gain.value = props.instTracks[control.idx].sounding ? 1 : 0;
 
         // connect nodes - main sitar string

--- a/src/ts/model/chikari.ts
+++ b/src/ts/model/chikari.ts
@@ -46,7 +46,6 @@ class Chikari {
   toJSON() {
         return {
           fundamental: this.fundamental,
-          pitches: this.pitches.map(p => p.toJSON()),
           uniqueId: this.uniqueId
         }
   }

--- a/src/ts/model/piece.ts
+++ b/src/ts/model/piece.ts
@@ -505,17 +505,7 @@ class Piece {
   }
 
   chikariFreqs(instIdx: number) {
-    const allChikaris: Chikari[] = [];
-    this.phraseGrid[instIdx].forEach(p => {
-      const chikaris = Object.values(p.chikaris);
-      allChikaris.push(...chikaris)
-    });
-    if (allChikaris.length === 0) {
-      return [this.raga.fundamental * 2, this.raga.fundamental * 4]
-    } else {
-      // console.log(allChikaris[0].pitches)
-      return allChikaris[0].pitches.slice(0, 2).map(p => p.frequency);
-    }
+    return this.raga.chikariPitches.map(p => p ? p.frequency : 0);
   }
 
   updateFundamental(fundamental: number) {

--- a/src/ts/model/raga.ts
+++ b/src/ts/model/raga.ts
@@ -340,10 +340,34 @@ class Raga {
 	return ratios
   }
 
-  get chikariPitches() {
+  get chikariPitches(): (Pitch | null)[] {
+	const ratios = this.stratifiedRatios;
+	const f = this.fundamental;
+
+	// String 2: Pa if present in raga, otherwise silent
+	let paPitch: Pitch | null = null;
+	if (this.ruleSet.pa) {
+	  paPitch = new Pitch({ swara: 'pa', oct: 1, fundamental: f, ratios });
+	}
+
+	// String 3: Ga if exactly one variant present, otherwise silent
+	let gaPitch: Pitch | null = null;
+	const gaRule = this.ruleSet.ga;
+	if (typeof gaRule === 'object') {
+	  const hasLowered = gaRule.lowered;
+	  const hasRaised = gaRule.raised;
+	  if (hasLowered && !hasRaised) {
+		gaPitch = new Pitch({ swara: 'ga', oct: 1, raised: false, fundamental: f, ratios });
+	  } else if (hasRaised && !hasLowered) {
+		gaPitch = new Pitch({ swara: 'ga', oct: 1, raised: true, fundamental: f, ratios });
+	  }
+	}
+
 	return [
-	  new Pitch({ swara: 's', oct: 2, fundamental: this.fundamental }),
-	  new Pitch({ swara: 's', oct: 1, fundamental: this.fundamental }),
+	  new Pitch({ swara: 's', oct: 2, fundamental: f, ratios }),
+	  new Pitch({ swara: 's', oct: 1, fundamental: f, ratios }),
+	  paPitch,
+	  gaPitch,
 	]
   }
 

--- a/src/ts/tests/chikari.test.ts
+++ b/src/ts/tests/chikari.test.ts
@@ -1,11 +1,28 @@
 import { expect, test } from 'vitest';
 import { Chikari, Pitch } from '@model';
 
-test('Chikari serialization', () => {
+test('Chikari serialization omits pitches', () => {
   const pitches = [new Pitch({ swara: 's', oct: 1 }), new Pitch({ swara: 'p' })];
   const c = new Chikari({ pitches, fundamental: 440 });
   expect(typeof c.uniqueId).toBe('string');
   const json = c.toJSON();
+  expect(json).toEqual({ fundamental: 440, uniqueId: c.uniqueId });
+  expect(json).not.toHaveProperty('pitches');
   const copy = Chikari.fromJSON(json);
   expect(copy.toJSON()).toEqual(json);
+});
+
+test('Chikari fromJSON handles legacy data with pitches', () => {
+  const legacyData = {
+    fundamental: 261.63,
+    uniqueId: 'test-id',
+    pitches: [
+      { swara: 0, raised: true, oct: 2, ratios: [1, [1.06, 1.12], [1.19, 1.26], [1.33, 1.41], 1.5, [1.59, 1.68], [1.78, 1.89]], fundamental: 261.63, logOffset: 0 },
+      { swara: 0, raised: true, oct: 1, ratios: [1, [1.06, 1.12], [1.19, 1.26], [1.33, 1.41], 1.5, [1.59, 1.68], [1.78, 1.89]], fundamental: 261.63, logOffset: 0 },
+    ],
+  };
+  const c = Chikari.fromJSON(legacyData);
+  expect(c.uniqueId).toBe('test-id');
+  expect(c.fundamental).toBe(261.63);
+  expect(c.pitches.length).toBe(2);
 });

--- a/src/ts/tests/piece.test.ts
+++ b/src/ts/tests/piece.test.ts
@@ -203,7 +203,7 @@ test('Piece method coverage', () => {
   expect(piece.trajIdxs.length).toBeGreaterThan(0);
   expect(piece.trajIdxsGrid[0]).toEqual(piece.trajIdxs);
 
-  expect(piece.chikariFreqs(0)).toEqual([piece.raga.fundamental * 2, piece.raga.fundamental * 4]);
+  expect(piece.chikariFreqs(0)).toEqual(piece.raga.chikariPitches.map(p => p ? p.frequency : 0));
   piece.updateFundamental(300);
   expect(piece.raga.fundamental).toBe(300);
   expect(p1.trajectories[0].pitches[0].fundamental).toBe(300);
@@ -346,10 +346,10 @@ test('track and group helpers on multiple tracks', () => {
   expect(piece.pIdxFromGroup(group)).toBe(0);
   expect(piece.mostRecentTraj(0.75, 0)).toBe(tA1);
 
-  // add a chikari so frequencies come from it
+  // chikari frequencies now come from the raga, not from chikari objects
   const chikari = new Chikari({ fundamental: piece.raga.fundamental });
   piece.phraseGrid[0][0].chikaris['0.00'] = chikari;
-  expect(piece.chikariFreqs(0)).toEqual(chikari.pitches.slice(0, 2).map(p => p.frequency));
+  expect(piece.chikariFreqs(0)).toEqual(piece.raga.chikariPitches.map(p => p ? p.frequency : 0));
 });
 
 test('meters and instrumentation update duration arrays', () => {
@@ -489,7 +489,7 @@ test('mostRecentTraj and chikariFreqs with chikaris', () => {
   const firstTraj = piece.phraseGrid[0][0].trajectories[0];
   const chikari = piece.phraseGrid[0][0].chikaris['0.25'];
   expect(piece.mostRecentTraj(0.6, 0)).toBe(firstTraj);
-  expect(piece.chikariFreqs(0)).toEqual(chikari.pitches.slice(0, 2).map(p => p.frequency));
+  expect(piece.chikariFreqs(0)).toEqual(piece.raga.chikariPitches.map(p => p ? p.frequency : 0));
 });
 
 test('addMeter overlap detection and removeMeter correctness', () => {

--- a/src/ts/tests/raga.test.ts
+++ b/src/ts/tests/raga.test.ts
@@ -189,9 +189,12 @@ test('defaultRaga', () => {
     [2 ** (10 / 12), 2 ** (11 / 12)]
   ];
   expect(r.stratifiedRatios).toEqual(sRatios);
+  const sR = r.stratifiedRatios;
   expect(r.chikariPitches).toEqual([
-    new Pitch({ swara: 0, oct: 2, fundamental: 261.63 }),
-    new Pitch({ swara: 0, oct: 1, fundamental: 261.63 }),
+    new Pitch({ swara: 0, oct: 2, fundamental: 261.63, ratios: sR }),
+    new Pitch({ swara: 0, oct: 1, fundamental: 261.63, ratios: sR }),
+    new Pitch({ swara: 'pa', oct: 1, fundamental: 261.63, ratios: sR }),
+    new Pitch({ swara: 'ga', oct: 1, raised: true, fundamental: 261.63, ratios: sR }),
   ])
   const hardCodedFreqs = [
     110.00186456141468, 123.47291821345574,
@@ -721,9 +724,12 @@ test('model raga core utilities', () => {
   ];
   expect(r.stratifiedRatios).toEqual(expectedRatios);
 
+  const sR2 = r.stratifiedRatios;
   expect(r.chikariPitches).toEqual([
-    new Pitch({ swara: 's', oct: 2, fundamental: r.fundamental }),
-    new Pitch({ swara: 's', oct: 1, fundamental: r.fundamental }),
+    new Pitch({ swara: 's', oct: 2, fundamental: r.fundamental, ratios: sR2 }),
+    new Pitch({ swara: 's', oct: 1, fundamental: r.fundamental, ratios: sR2 }),
+    new Pitch({ swara: 'pa', oct: 1, fundamental: r.fundamental, ratios: sR2 }),
+    new Pitch({ swara: 'ga', oct: 1, raised: true, fundamental: r.fundamental, ratios: sR2 }),
   ]);
 
   const hardCodedFreqs = [


### PR DESCRIPTION
## Summary
- Chikari strings now derive their pitches from the active raga's ruleSet and tuning, fixing clashing harmonies (e.g. Bageshree playing tivra Ga instead of komal Ga)
- Strings 2 (Pa) and 3 (Ga) are automatically silenced when their pitch is absent from the raga or ambiguous (both variants present)
- Strum order is computed from actual pitch frequencies (low-to-high) at the application level, sent to the worklet via port message
- Chikari serialization no longer includes redundant pitch data (~95% size reduction per chikari object, self-cleaning on next save)

## Test plan
- [x] All 293 existing tests pass
- [x] Production build succeeds
- [ ] Manual test: play Bageshree transcription — komal Ga should sound on string 3
- [ ] Manual test: raga without Pa (e.g. Malkauns) — strings 2+3 should be silent
- [ ] Manual test: Bhairavi (both Ga variants) — string 3 should be silent
- [ ] Manual test: verify transposition still works across all 4 strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)