### PR TITLE
fix: apply motion + admin rules to jon.myers.sound@gmail.com account

### DIFF
--- a/src/comps/analysis/AnalyzerComponent.vue
+++ b/src/comps/analysis/AnalyzerComponent.vue
@@ -727,14 +727,12 @@ export default defineComponent({
     },
 
     admin() {
-      const jmId = '634d9506a6a3647e543b7641';
-      const dnId = '63595c60a6a3647e54a62853';
-      const currentId = this.$store.state.userID;
-      if (currentId === jmId || currentId === dnId) {
-        return true;
-      } else {
-        return false;
-      }
+      const adminIds = [
+        '634d9506a6a3647e543b7641', // jbmyers@ucsc.edu
+        '67bcba9496f2cea9ceb736c2', // jon.myers.sound@gmail.com
+        '63595c60a6a3647e54a62853', // Dard Neuman
+      ];
+      return adminIds.includes(this.$store.state.userID);
     },
 
     vocal() {

--- a/src/comps/editor/EditorComponent.vue
+++ b/src/comps/editor/EditorComponent.vue
@@ -377,6 +377,7 @@ import {
   updateTranscriptionViewed
 } from '@/js/serverCalls.ts';
 import { Meter, Pulse } from '@/js/meter.ts';
+import { suppressMotion } from '@/js/motionPrefs.ts';
 import EditorAudioPlayer from '@/comps/editor/audioPlayer/EditorAudioPlayer.vue';
 import TrajSelectPanel from '@/comps/editor/TrajSelectPanel.vue';
 import ContextMenu from'@/comps/ContextMenu.vue';
@@ -892,7 +893,7 @@ export default defineComponent({
     this.throttledAlterVibObj = throttle(this.alterVibObj, 16);
     this.throttledRenderMeter = throttle(this.renderMeter, 100);
     this.throttledRefreshSargamLines = throttle(this.refreshSargamLines, 100);
-    if (this.$store.state.userID === '634d9506a6a3647e543b7641') {
+    if (suppressMotion(this.$store.state.userID)) {
       this.playheadAnimation = PlayheadAnimations.Block;
     }
 

--- a/src/comps/editor/Renderer.vue
+++ b/src/comps/editor/Renderer.vue
@@ -228,6 +228,7 @@ import {
   toRef
 } from 'vue';
 import { throttle } from 'lodash';
+import { suppressMotion } from '@/js/motionPrefs.ts';
 
 import SpectrogramLayer from '@/comps/editor/renderer/SpectrogramLayer.vue';
 import XAxis from '@/comps/editor/renderer/XAxis.vue';
@@ -872,13 +873,13 @@ export default defineComponent({
     }, 16);
 
     const onWheel = (e: WheelEvent) => {
-      if (store.state.userID === '634d9506a6a3647e543b7641') {
+      if (suppressMotion(store.state.userID)) {
         e.preventDefault();
         e.stopPropagation();
       }
     };
     const onTouchMove = (e: TouchEvent) => {
-      if (store.state.userID === '634d9506a6a3647e543b7641') {
+      if (suppressMotion(store.state.userID)) {
         e.preventDefault();
         e.stopPropagation();
       }

--- a/src/comps/editor/audioPlayer/SpectrogramControls.vue
+++ b/src/comps/editor/audioPlayer/SpectrogramControls.vue
@@ -397,6 +397,7 @@ import {
   updateSavedDisplaySettings,
   deleteSavedDisplaySettings
 } from '@/js/serverCalls.ts'
+import { suppressMotion } from '@/js/motionPrefs.ts';
 import { useStore } from 'vuex';
 import { v4 as uuidv4 } from 'uuid';
 export default defineComponent({
@@ -1202,7 +1203,7 @@ export default defineComponent({
       if (s.playheadAnimationStyle !== undefined) {
         playheadAnimationProxy.value = s.playheadAnimationStyle;
       }
-      if (store.state.userID === '634d9506a6a3647e543b7641') {
+      if (suppressMotion(store.state.userID)) {
         playheadAnimationProxy.value = PlayheadAnimations.DottedLine;
       }
       if (s.highlightTrajs !== undefined) {

--- a/src/js/motionPrefs.ts
+++ b/src/js/motionPrefs.ts
@@ -1,0 +1,12 @@
+// Users for whom on-screen motion must be suppressed (non-animated playhead,
+// no wheel/touch scrolling) — motion sensitivity.
+const motionSensitiveUserIDs = [
+  '634d9506a6a3647e543b7641', // jbmyers@ucsc.edu
+  '67bcba9496f2cea9ceb736c2', // jon.myers.sound@gmail.com
+];
+
+const suppressMotion = (userID?: string) => {
+  return userID !== undefined && motionSensitiveUserIDs.includes(userID);
+};
+
+export { motionSensitiveUserIDs, suppressMotion };


### PR DESCRIPTION
## Summary

Four rules were hardcoded to the `jbmyers@ucsc.edu` user ID (`634d9506a6a3647e543b7641`). This extends them to `jon.myers.sound@gmail.com` (`67bcba9496f2cea9ceb736c2`), which is now the primary login.

## Motion suppression (motion sensitivity)

Consolidated behind a shared `suppressMotion()` predicate in the new `src/js/motionPrefs.ts`. Three sites previously compared the raw ObjectId inline:

- `EditorComponent.vue` — playhead forced to `Block` on editor mount
- `SpectrogramControls.vue` — playhead forced to `DottedLine` when a display setting loads (overriding the saved setting)
- `Renderer.vue` — wheel + touch scrolling suppressed in the renderer

Net behavior on the gmail account is now identical to the UCSC account: the playhead never animates, and the renderer does not scroll under wheel/touch.

## Admin gate

`AnalyzerComponent.vue`'s `admin` computed (which unlocks the "Excel Datasets" analysis type) becomes an `adminIds` list rather than a chain of `===` comparisons. Membership: `jbmyers@ucsc.edu`, `jon.myers.sound@gmail.com`, Dard Neuman.

## Notes

- No comparison against the raw UCSC ObjectId survives; the ID now appears only inside the two declarative lists, so adding a future account is a one-line change.
- Frontend-only — no server deploy needed.

## Test plan

- `pnpm build` — clean; new ID verified present in both the `EditorComponent` and `AnalyzerComponent` chunks
- `pnpm test` — 314 tests passed across 16 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)